### PR TITLE
Update i3-workspace-names-daemon's dependencies

### DIFF
--- a/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0-r1.ebuild
+++ b/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2021-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8

--- a/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0-r1.ebuild
+++ b/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTURILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{8..10} )
+inherit distutils-r1
+
+DESCRIPTION="Dynamically update workspace names in i3wm based on their content."
+HOMEPAGE="
+	https://github.com/cboddy/i3-workspace-names-daemon
+	https://pypi.org/project/i3-workspace-names-daemon
+"
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/cboddy/i3-workspace-names-daemon.git"
+else
+	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+
+RDEPEND="
+	|| ( x11-wm/i3 x11-wm/i3-gaps )
+	media-fonts/fontawesome
+	dev-python/i3ipc[${PYTHON_USEDEP}]
+"

--- a/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0.ebuild
+++ b/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0.ebuild
@@ -3,10 +3,10 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
-DESCRIPTION="A daemon script to dynamically update workspace names in i3wm based on their content."
+DESCRIPTION="Dynamically update workspace names in i3wm based on their content."
 HOMEPAGE="
 	https://github.com/cboddy/i3-workspace-names-daemon
 	https://pypi.org/project/i3-workspace-names-daemon
@@ -17,10 +17,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-DEPEND=""
-RDEPEND="
+DEPEND="
 	|| ( x11-wm/i3 x11-wm/i3-gaps )
 	media-fonts/fontawesome
-	${DEPEND}
+	dev-python/i3ipc
 "
-BDEPEND=""

--- a/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0.ebuild
+++ b/x11-misc/i3-workspace-names-daemon/i3-workspace-names-daemon-0.15.0.ebuild
@@ -3,10 +3,10 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8,9} )
 inherit distutils-r1
 
-DESCRIPTION="Dynamically update workspace names in i3wm based on their content."
+DESCRIPTION="A daemon script to dynamically update workspace names in i3wm based on their content."
 HOMEPAGE="
 	https://github.com/cboddy/i3-workspace-names-daemon
 	https://pypi.org/project/i3-workspace-names-daemon
@@ -17,8 +17,10 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-DEPEND="
+DEPEND=""
+RDEPEND="
 	|| ( x11-wm/i3 x11-wm/i3-gaps )
 	media-fonts/fontawesome
-	dev-python/i3ipc
+	${DEPEND}
 "
+BDEPEND=""

--- a/x11-misc/i3-workspace-names-daemon/metadata.xml
+++ b/x11-misc/i3-workspace-names-daemon/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>courser4848@gmail.com</email>
+		<name>xecua</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">cboddy/i3-workspace-names-daemon</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
多分3.10でも動く(テストがないのでわからんけど手元では動いてそう)
あと依存が抜けてたので追加